### PR TITLE
Support for Scalding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,8 @@
 		<hadoop2.version>2.2.0</hadoop2.version>
 		<cascading.version>2.5.0</cascading.version>
 		<hive.version>0.12.0</hive.version>
+		<scala.version>2.10</scala.version>
+		<scalding.version>0.9.1</scalding.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -179,6 +181,11 @@
 			<version>${cascading.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.twitter</groupId>
+			<artifactId>scalding-core_${scala.version}</artifactId>
+			<version>${scalding.version}</version>
+		</dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
@@ -229,7 +236,7 @@
 			<version>1.3.174</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
+	<dependency>
             <groupId>com.twitter</groupId>
             <artifactId>parquet-hive-bundle</artifactId>
             <version>1.3.2</version>
@@ -256,6 +263,28 @@
                     <argLine>-Xmx1024m</argLine>
                 </configuration>
             </plugin>
+		<plugin>
+			<groupId>org.scala-tools</groupId>
+			<artifactId>maven-scala-plugin</artifactId>
+			<version>2.14.2</version>
+			<executions>
+				<execution>
+					<id>scala-compile-first</id>
+					<phase>process-resources</phase>
+					<goals>
+						<goal>add-source</goal>
+						<goal>compile</goal>
+					</goals>
+				</execution>
+				<execution>
+					<id>scala-test-compile</id>
+					<phase>process-test-resources</phase>
+					<goals>
+						<goal>testCompile</goal>
+					</goals>
+				</execution>
+			</executions>
+		</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/scala/com/twitter/scalding/ColumnarSerDeSource.scala
+++ b/src/main/scala/com/twitter/scalding/ColumnarSerDeSource.scala
@@ -1,0 +1,68 @@
+package com.twitter.scalding
+
+import scala.collection.JavaConversions._
+
+import cascading.scheme.Scheme
+import cascading.tap.SinkMode
+import cascading.tuple.Fields
+import com.twitter.scalding
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapred.OutputCollector
+import org.apache.hadoop.mapred.RecordReader
+
+////
+// trait ColumnarSerDeScheme -
+// @columns:                 array of column names
+// @columnTypes:             array of column type names (parallel to @columns)
+// @defaultType:             default hive type name for missing types
+trait ColumnarSerDeScheme extends SchemedSource {
+    // override this to name the source columns
+    val columns:List[String]
+    // override this to associate a type with each column name
+    val columnTypes:List[String] = Nil
+    // override this to change the default type name for columns
+    val defaultType:String = "string"
+ 
+    ////
+    // typeNames() - convenience method which adds missing type info
+    //
+    // Return:
+    //   @columnTypes plus any missing values set to @defaultType
+    def typeNames:List[String] = columnTypes ++ List.fill(columns.size)(defaultType)
+}
+
+////
+// case class RCFile - RCFile ColumnarSerDeScheme source
+// @p:           source path
+// @columns:     column names
+// @columnTypes: column type names
+// @sinkMode:    cascading sink mode option
+case class RCFile(p:String
+                 ,override val columns:List[String]
+                 ,override val columnTypes:List[String] = Nil
+                 ,override val sinkMode:SinkMode = SinkMode.REPLACE)
+    extends FixedPathSource(p)
+    with ColumnarSerDeScheme {
+    ////
+    // @hdfsScheme: specifies the hdfs scheme to be an RCFile
+    override val hdfsScheme = new cascading.hive.RCFile(columns.toArray, typeNames.toArray)
+    .asInstanceOf[Scheme[JobConf, RecordReader[_,_], OutputCollector[_,_],_,_]]
+}
+
+////
+// case class ORCFile - ORCFile ColumnarSerDeScheme source
+// @p:            source path
+// @columns:      column names
+// @columnTypes:  column type names
+// @sinkMode:     cascading sink mode option
+case class ORCFile(p:String
+                  ,override val columns:List[String]
+                  ,override val columnTypes:List[String] = Nil
+                  ,override val sinkMode:SinkMode = SinkMode.REPLACE)
+    extends FixedPathSource(p)
+    with ColumnarSerDeScheme {
+    ////
+    // @hdfsScheme: specifies the hdfs scheme to be an ORCFile
+    override val hdfsScheme = new cascading.hive.ORCFile(columns.toArray, typeNames.toArray)
+    .asInstanceOf[Scheme[JobConf, RecordReader[_,_], OutputCollector[_,_],_,_]]
+}


### PR DESCRIPTION
This patch provides scalding integration for cascading.hive.

Specifically it creates two sub-classes of FixedPathSource one for each of RCFile and ORCFile.

These classes are quire simple to use, just requiring the caller to provide field names and types as required by the underlying Cascading scheme objects. For convenience the types will default to "string" if underspecified -- which is a fairly safe default.
