### PR TITLE
adds support for complex hive types

### DIFF
--- a/src/main/java/cascading/hive/HiveSchemaUtil.java
+++ b/src/main/java/cascading/hive/HiveSchemaUtil.java
@@ -15,36 +15,66 @@
 package cascading.hive;
 
 import java.util.ArrayList;
+import java.util.List;
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.CharStream;
+import org.antlr.runtime.RecognitionException;
+import org.antlr.runtime.Token;
+import org.antlr.runtime.TokenRewriteStream;
+import org.antlr.runtime.TokenStream;
+import org.antlr.runtime.tree.CommonTree;
+import org.antlr.runtime.tree.CommonTreeAdaptor;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.parser.ExpressionTree;
+import org.apache.hadoop.hive.ql.parse.ASTErrorNode;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveLexer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 
 /**
  *
  */
 public class HiveSchemaUtil {
+  public static ArrayList<String>[] parse(String schema) {
+    HiveLexer lexer = new HiveLexer(new ExpressionTree.ANTLRNoCaseStringStream(schema));
+    HiveParser parser = new HiveParser(new TokenRewriteStream(lexer));
+    parser.setTreeAdaptor(new CommonTreeAdaptor() {
+      @Override
+      public Object create(Token payload) {
+        return new ASTNode(payload);
+      }
 
-    /**
-     * The method to parse hive schema string, returns an array of two list instances, the first is for field names, the
-     * second for types.
-     * @param schema hive scheme
-     * @return List of String
-     */
-    public static ArrayList<String>[] parse(String schema) {
-        String[] pairs = schema.split(",");
-        ArrayList<String> names = new ArrayList<String>(pairs.length);
-        ArrayList<String> types = new ArrayList<String>(pairs.length);
-        ArrayList[] ret = new ArrayList[] {names, types};
+      @Override
+      public Object dupNode(Object t) { return create(((CommonTree)t).token); }
 
-        for (String str : pairs)  {
-           String[] pair = str.trim().split(" ");
-           if (pair.length != 2) {
-               throw new RuntimeException("malformed <name,type> pair found: " + str );
-           }
-           names.add(pair[0].trim().toLowerCase());
-           types.add(pair[1].trim().toLowerCase());
-        }
-        if (names.size() == 0) {
-            throw new RuntimeException("No name/type found, maybe malformed shema: " + schema );
-        }
-
-        return ret;
+      @Override
+      public Object errorNode(TokenStream input, Token start, Token stop, RecognitionException e) {
+        return new ASTErrorNode(input, start, stop, e);
+      }
+    });
+    HiveParser.columnNameTypeList_return columns;
+    try {
+      columns = parser.columnNameTypeList();
+    } catch (RecognitionException e) {
+      throw new RuntimeException("malformed <name/type> pair found: " + parser.getErrorHeader(e) + " " + e.getMessage());
     }
+    ASTNode root = (ASTNode) columns.getTree();
+    List<FieldSchema> list;
+    try {
+      list = BaseSemanticAnalyzer.getColumns(root, false);
+    } catch (SemanticException e) {
+      throw new RuntimeException("malformed <name/type> pair found: " + e.getMessage());
+    }
+    ArrayList<String> names = new ArrayList<>();
+    ArrayList<String> types = new ArrayList<>();
+    ArrayList[] ret = new ArrayList[] {names, types};
+
+    for (FieldSchema fs : list) {
+      names.add(fs.getName());
+      types.add(fs.getType());
+    }
+    return ret;
+  }
 }

--- a/src/main/java/cascading/hive/HiveSchemaUtil.java
+++ b/src/main/java/cascading/hive/HiveSchemaUtil.java
@@ -67,8 +67,8 @@ public class HiveSchemaUtil {
     } catch (SemanticException e) {
       throw new RuntimeException("malformed <name/type> pair found: " + e.getMessage());
     }
-    ArrayList<String> names = new ArrayList<>();
-    ArrayList<String> types = new ArrayList<>();
+    ArrayList<String> names = new ArrayList<String>();
+    ArrayList<String> types = new ArrayList<String>();
     ArrayList[] ret = new ArrayList[] {names, types};
 
     for (FieldSchema fs : list) {

--- a/src/test/java/cascading/hive/HiveSchemaUtilTest.java
+++ b/src/test/java/cascading/hive/HiveSchemaUtilTest.java
@@ -76,7 +76,7 @@ public class HiveSchemaUtilTest {
     List<String> expectedNames = new ArrayList<String>(4);
     expectedNames.add("complex");
     List<String> expectedTypes = new ArrayList<String>(4);
-    expectedTypes.add("array");
+    expectedTypes.add("array<string>");
 
     assertEquals(expectedNames, nameList);
     assertEquals(expectedTypes, typeList);

--- a/src/test/java/cascading/hive/HiveSchemaUtilTest.java
+++ b/src/test/java/cascading/hive/HiveSchemaUtilTest.java
@@ -14,37 +14,91 @@
 
 package cascading.hive;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.hive.ql.lib.Node;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 
 /**
  */
 public class HiveSchemaUtilTest {
+  @Test
+  public void testParsePrimitive() {
+    String schema = "id INT, name STRING, price DOUBLE, \n description STRING";
+    List<String>[] lists = HiveSchemaUtil.parse(schema);
+    List<String> nameList = lists[0];
+    List<String> typeList = lists[1];
 
-    @Test
-    public void testParse() {
-        String schema = "id INT, name STRING, price DOUBLE, \n description STRING";
-        List<String>[] lists = HiveSchemaUtil.parse(schema);
-        List<String> nameList = lists[0];
-        List<String> typeList = lists[1];
+    List<String> expectedNames = new ArrayList<String>(4);
+    expectedNames.add("id");
+    expectedNames.add("name");
+    expectedNames.add("price");
+    expectedNames.add("description");
+    List<String> expectedTypes = new ArrayList<String>(4);
+    expectedTypes.add("int");
+    expectedTypes.add("string");
+    expectedTypes.add("double");
+    expectedTypes.add("string");
 
-        List<String> expectedNames = new ArrayList<String>(4);
-        expectedNames.add("id");
-        expectedNames.add("name");
-        expectedNames.add("price");
-        expectedNames.add("description");
-        List<String> expectedTypes = new ArrayList<String>(4);
-        expectedTypes.add("int");
-        expectedTypes.add("string");
-        expectedTypes.add("double");
-        expectedTypes.add("string");
+    assertEquals(expectedNames, nameList);
+    assertEquals(expectedTypes, typeList);
+  }
 
-        assertEquals(expectedNames, nameList);
-        assertEquals(expectedTypes, typeList);
+  @Test
+  public void testParsePrimitiveLower() {
+    String schema = "col1 int, col2 string";
+    List<String>[] lists = HiveSchemaUtil.parse(schema);
+    List<String> nameList = lists[0];
+    List<String> typeList = lists[1];
 
-    }
+    List<String> expectedNames = new ArrayList<String>(4);
+    expectedNames.add("col1");
+    expectedNames.add("col2");
+    List<String> expectedTypes = new ArrayList<String>(4);
+    expectedTypes.add("int");
+    expectedTypes.add("string");
+
+    assertEquals(expectedNames, nameList);
+    assertEquals(expectedTypes, typeList);
+  }
+
+  @Test
+  public void testParseArray() {
+    String schema = "`complex` ARRAY<STRING>";
+    List<String>[] lists = HiveSchemaUtil.parse(schema);
+    List<String> nameList = lists[0];
+    List<String> typeList = lists[1];
+
+    List<String> expectedNames = new ArrayList<String>(4);
+    expectedNames.add("complex");
+    List<String> expectedTypes = new ArrayList<String>(4);
+    expectedTypes.add("array");
+
+    assertEquals(expectedNames, nameList);
+    assertEquals(expectedTypes, typeList);
+  }
+
+  @Test
+  public void testParseComplex() {
+    String schema = "`id` INT, `name` STRING, `arr` ARRAY<STRUCT<`one`:STRING,`two`:BIGINT,`three`:STRUCT<`four`:STRING>,`five`:STRING>>";
+    List<String>[] lists = HiveSchemaUtil.parse(schema);
+    List<String> nameList = lists[0];
+    List<String> typeList = lists[1];
+
+    List<String> expectedNames = new ArrayList<String>(4);
+    expectedNames.add("id");
+    expectedNames.add("name");
+    expectedNames.add("arr");
+    List<String> expectedTypes = new ArrayList<String>(4);
+    expectedTypes.add("int");
+    expectedTypes.add("string");
+    expectedTypes.add("array<struct<one:string,two:bigint,three:struct<four:string>,five:string>>");
+
+    assertEquals(expectedNames, nameList);
+    assertEquals(expectedTypes, typeList);
+  }
 }


### PR DESCRIPTION
This couples the HiveSchemaUtil.parse method closer together with Hive
implementation, which is a little gross. However, it does so as
minimally as possible, and retains compatibility up to the current
0.14-SNAPSHOT release.
